### PR TITLE
Added actions and reducers for parent courses booking

### DIFF
--- a/src/redux/actions/parentActions.js
+++ b/src/redux/actions/parentActions.js
@@ -70,7 +70,7 @@ export const getInbox = dispatch => {
 export const signupForCourse = () => dispatch => {
   dispatch({ type: SIGNUP_COURSE_ACTION });
   axios
-    .post('https://dummyapi.io/data/v1/user/60d0fe4f5311236168a109ca', {
+    .get('https://dummyapi.io/data/v1/user/60d0fe4f5311236168a109ca', {
       crossdomain: true,
     })
     .then(res => {

--- a/src/redux/actions/parentActions.js
+++ b/src/redux/actions/parentActions.js
@@ -14,6 +14,9 @@ export const GET_SESSIONS_SUCCESS = 'GET_SESSIONS_SUCCESS';
 export const GET_INBOX_ACTION = 'GET_INBOX';
 export const GET_INBOX_SUCCESS = 'GET_INBOX_SUCCESS';
 
+export const SIGNUP_COURSE_ACTION = 'SIGNUP_COURSE';
+export const SIGNUP_COURSE_SUCCESS = 'SIGNUP_SUCCESS';
+
 export const getChildren = () => dispatch => {
   dispatch({ type: GET_CHILDREN_ACTION });
   axios
@@ -58,6 +61,20 @@ export const getInbox = dispatch => {
     })
     .then(res => {
       dispatch({ type: GET_INBOX_SUCCESS, payload: res.data });
+    })
+    .catch(err => {
+      dispatch({ type: ERROR_ACTION, payload: err });
+    });
+};
+
+export const signupForCourse = () => dispatch => {
+  dispatch({ type: SIGNUP_COURSE_ACTION });
+  axios
+    .post('https://dummyapi.io/data/v1/user/60d0fe4f5311236168a109ca', {
+      crossdomain: true,
+    })
+    .then(res => {
+      dispatch({ type: SIGNUP_COURSE_ACTION, payload: res.data });
     })
     .catch(err => {
       dispatch({ type: ERROR_ACTION, payload: err });

--- a/src/redux/reducers/parentReducer.js
+++ b/src/redux/reducers/parentReducer.js
@@ -3,6 +3,7 @@ import {
   GET_COURSES_ACTION,
   GET_INBOX_ACTION,
   GET_SESSIONS_ACTION,
+  SIGNUP_COURSE_ACTION,
 } from '../actions/parentActions';
 
 export const initialState = {
@@ -209,6 +210,11 @@ const reducer = (state = initialState, action) => {
       return {
         ...state,
         inbox: action.payload,
+      };
+    case SIGNUP_COURSE_ACTION:
+      return {
+        ...state,
+        courses: action.payload,
       };
     default:
       return state;


### PR DESCRIPTION
What I did:
- created signup courses & signup courses success action 
- created a signup courses reducer

Files changed:
- ParentActions.js
- ParentReducer.js

Why were they changed:
- to manage and update state when parent want to add courses for their children

co-author: @chelseaceballos 

!([loom](https://www.loom.com/share/3c15f261a97c4f4691976f2546189174))