### PR TITLE
Updated the parent sidebar and changed the banner slightly

### DIFF
--- a/src/components/pages/ParentBooking/index.js
+++ b/src/components/pages/ParentBooking/index.js
@@ -24,9 +24,6 @@ function ParentBooking() {
       </Sider>
       <Content>
         <Banner />
-        <div className="bookingBtn">
-          <p>Continue To Review Booking</p>
-        </div>
       </Content>
     </Layout>
   );

--- a/src/components/pages/ParentHome/ParentSidebar.js
+++ b/src/components/pages/ParentHome/ParentSidebar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Menu } from 'antd';
 import 'antd/dist/antd.css';
+import { Link } from 'react-router-dom';
 
 import {
   TeamOutlined,
@@ -14,6 +15,7 @@ import {
 
 function ParentSidebar(props) {
   const { collapsed } = props;
+
   const handleClick = e => {
     console.log('click ', e);
   };
@@ -23,7 +25,7 @@ function ParentSidebar(props) {
       <Menu
         className="parent-dashboard-sidebar"
         onClick={handleClick}
-        defaultSelectedKeys={['1']}
+        defaultSelectedKeys={['2']}
         defaultOpenKeys={['sub1']}
         style={{ height: '100vh' }}
         mode="inline"
@@ -39,22 +41,14 @@ function ParentSidebar(props) {
           CoderHeroes
         </Menu.Item>
         <Menu.Item key="2" icon={<HomeOutlined />}>
-          Dashboard
+          <Link to="/parent" className="link">
+            Dashboard
+          </Link>
         </Menu.Item>
-        <Menu.Item key="3" icon={<TeamOutlined />}>
-          Family
-        </Menu.Item>
-        <Menu.Item key="4" icon={<ReadOutlined />}>
-          Booking
-        </Menu.Item>
-        <Menu.Item key="5" icon={<CalendarOutlined />}>
-          Schedule
-        </Menu.Item>
-        <Menu.Item key="6" icon={<MailOutlined />}>
-          Inbox
-        </Menu.Item>
-        <Menu.Item key="7" icon={<SettingOutlined />}>
-          Settings
+        <Menu.Item key="3" icon={<ReadOutlined />}>
+          <Link to="/parent-booking" className="link">
+            Booking
+          </Link>
         </Menu.Item>
       </Menu>
     </div>

--- a/src/components/pages/ParentHome/index.js
+++ b/src/components/pages/ParentHome/index.js
@@ -1,15 +1,10 @@
 import React, { useState } from 'react';
-import ChildrenList from './ChildrenList';
 import ParentCalendar from './ParentCalendar';
-import ParentResources from './ParentResources';
 import { dummyData } from '../../../dummyData';
-import Button from '../../common/Button';
 import { useHistory } from 'react-router';
 import { Layout, Row, Col } from 'antd';
 import 'antd/dist/antd.css';
-import { UserAddOutlined, ScheduleOutlined } from '@ant-design/icons';
 import Banner from '../../common/Banner';
-import { ThunderboltFilled } from '@ant-design/icons';
 import ParentSidebar from './ParentSidebar';
 import AvailableCourses from './AvailableCourses';
 import './../../../styles/ParentStyles/index.less';
@@ -42,22 +37,9 @@ function ParentHome() {
         </Sider>
         <Content>
           <Banner />
-          <div className="banner-divs">
-            <div className="enroll-child">
-              <p>{<UserAddOutlined />} Enroll Child</p>
-            </div>
-            <div className="parent-find-courses">
-              <p> {<ScheduleOutlined />} Find Courses</p>
-            </div>
-          </div>
-
-          <Button buttonText={'Booking'} handleClick={handleClick} />
           <Layout>
             <Content>
               <Row justify="space-around" align="middle">
-                {/* <Col span={5}>
-                  <ParentResources />
-                </Col> */}
                 <Col span={20}>
                   <AvailableCourses />
                 </Col>

--- a/src/styles/ParentStyles/index.less
+++ b/src/styles/ParentStyles/index.less
@@ -7,22 +7,23 @@
 .dashboard-banner{
     background-color: #006C72; 
     padding: 10px 10px;
-    height: 25vh;
+    height: 19vh;
 }    
 
 .banner-conent{
-    margin-bottom: 20px;
     width: 40%;
     padding-left: 3rem;
     font-family: 'Ubuntu', sans-serif;
         h1{
             font-weight: bold;
             font-size: @h3;
+            margin-bottom: 0;
             color: #00cab7;
         }
         h2{
             font-size: 1.5rem;
             color: #fff;
+
             font-weight: light;
         }
     }
@@ -225,6 +226,22 @@ img{
     color: #00cab7;
     font-weight: bold;
     font-size: 1rem;
+}
+.ant-tabs-tab .ant-tabs-tab-active {
+    color: #00cab7;
+    font-weight: bold;
+    font-size: 1rem;
+}
+.ant-tabs-tab:hover {
+    color: #00cab7;
+}
+.ant-tabs-tab{
+    color: #a3a9b9;
+font-weight: bold;
+}
+
+.link{
+    color: #006C72 !important;
 }
 .ant-tabs-tab .ant-tabs-tab-active {
     color: #00cab7;


### PR DESCRIPTION
What I did:
- Took out any sidebar menus that were not being used
- Added Link so that we can navigate to the booking page with the sidebar
- made the banner a little slimmer to allow more content to be seen on the dashboard
- removed buttons that arent being used on the dashboard

Files changed:
- parentSidebar.js
- Parent/index.less
- ParentHome/index.js
- ParentBooking/index.js

Why they were changed:
- To make things cleaner and clear for the next cohort

co-author: @chelseaceballos 

!(loom)