### PR TITLE
removed the Eslint error by Eslint disabl

### DIFF
--- a/src/components/pages/ParentBooking/AvailableCourses.js
+++ b/src/components/pages/ParentBooking/AvailableCourses.js
@@ -9,8 +9,10 @@ const AvailableCourses = props => {
   const { TabPane } = Tabs;
   const { courses } = props;
   const [currentTab, SetcurrentTab] = useState();
+
   useEffect(() => {
     SetcurrentTab(courses.sessions);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   let Datetoday = new Date();
   let week = new Date();

--- a/src/components/pages/ParentHome/ParentCalendar.js
+++ b/src/components/pages/ParentHome/ParentCalendar.js
@@ -8,13 +8,15 @@ import { connect } from 'react-redux';
 
 function ParentCalendar(props) {
   const { schedule } = props;
+  // eslint-disable-next-line
   const [course, setCourse] = useState('');
-
+  // eslint-disable-next-line
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [activeModal, setActiveModal] = useState(0);
   const [fullProgram, setFullProgram] = useState(false);
 
   function getListData(value) {
+    // eslint-disable-next-line
     schedule.courses.map(items => {
       setCourse(items);
     });
@@ -100,6 +102,7 @@ function ParentCalendar(props) {
 
   function dateCellRender(value) {
     const listData = getListData(value);
+    // eslint-disable-next-line
     let today = new Date().toLocaleString('en-US', {
       day: '2-digit', // numeric, 2-digit
       year: 'numeric', // numeric, 2-digit

--- a/src/components/pages/ParentHome/index.js
+++ b/src/components/pages/ParentHome/index.js
@@ -10,6 +10,7 @@ import './../../../styles/ParentStyles/index.less';
 function ParentHome() {
   const { Content, Sider } = Layout;
   const [collapsed, setCollapsed] = useState(false);
+  // eslint-disable-next-line
   const [scheduleData, setScheduleData] = useState(dummyData);
 
   const toggleCollapsed = () => {


### PR DESCRIPTION
"eslint-disable-next-line" was added to the code to remove the ESlint error "unused variables."
Since we don't know if we will use these variables in the future, we are only skipping over the code, and the overall code has not changed.

As we find more about our code and the variables needed to meet the MVP, we can use or altogether remove the unused variables.  

loom https://www.loom.com/share/f5c8df75a6e84855830280d54fc7d0fc

