### PR TITLE
left only one  proceed-to-checkout Btn and deleted the rest

### DIFF
--- a/src/components/pages/ParentHome/Cart.js
+++ b/src/components/pages/ParentHome/Cart.js
@@ -70,9 +70,6 @@ function Cart(props) {
             </div>
             <div>
               <Button onClick={() => handleModal()}>Cancel booking</Button>
-              <Button type="primary" onClick={handleCheckout}>
-                Proceed to checkout
-              </Button>
             </div>
             {showModal ? (
               <Modal
@@ -99,7 +96,10 @@ function Cart(props) {
           </div>
         );
       })}
-      <div>Total: {total}</div>
+      <Button type="primary" onClick={handleCheckout}>
+        Proceed to checkout
+      </Button>
+      <div>Total: ${total}</div>
     </div>
   );
 }


### PR DESCRIPTION
There were one "proceed to checkout" button for each booking, but there should be only one, which leads to payment page, so I fixed that.

Loom [https://www.loom.com/share/dd41e2b7e7a3464193cf64143231c527](url)