### PR TITLE
removed the duplicate buttons on the sidebar for the parent dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7072,9 +7072,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001180",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001180.tgz",
-      "integrity": "sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw=="
+      "version": "1.0.30001298",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
+      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ=="
     },
     "canvas-fit": {
       "version": "1.5.0",

--- a/src/components/pages/ParentHome/ParentSidebar.js
+++ b/src/components/pages/ParentHome/ParentSidebar.js
@@ -75,22 +75,10 @@ const ParentSideBar = props => {
           <Link to="/logout">Logout</Link>
         </Menu.Item>
 
-        <Menu.Item key="family" icon={<HeartFilled fontSize="150px" />}>
-          <Link to="/family">Family</Link>
-        </Menu.Item>
-
-        <Menu.Item key="setting" icon={<ToolFilled fontSize="150px" />}>
-          <Link to="/settings">Settings</Link>
-        </Menu.Item>
-
         <Menu.Item key="4" icon={<ShoppingCartOutlined fontSize="150px" />}>
           <Link to="/cart" className="link">
             Cart <span>({cart.length})</span>
           </Link>
-        </Menu.Item>
-
-        <Menu.Item key="logout" icon={<ExportOutlined fontSize="150px" />}>
-          <Link to="/logout">Logout</Link>
         </Menu.Item>
       </Menu>
     </Sider>

--- a/src/components/pages/ParentHome/ParentSidebar.js
+++ b/src/components/pages/ParentHome/ParentSidebar.js
@@ -72,7 +72,7 @@ const ParentSideBar = props => {
         </Menu.Item>
 
         <Menu.Item key="logout" icon={<ExportOutlined fontSize="150px" />}>
-          <Link to="/logout">Logout</Link>
+          <Link to="/landing">Logout</Link>
         </Menu.Item>
 
         <Menu.Item key="4" icon={<ShoppingCartOutlined fontSize="150px" />}>


### PR DESCRIPTION
## Description

Removed the duplicate buttons that were appearing on the sidebar of the parent dashboard. The buttons were hardcoded into the sidebar component, I simply removed the repeated code.

Additionally, changed the logout button route from /logout to /landing so that a user is redirected to the landing page after logging out.

Link to trello card corresponding to this task: https://trello.com/c/SNVQkMsu/116-duplicate-buttons

Link to Loom recording: https://www.loom.com/share/3a14d644db904fcdb69bc62d3b51aa18

Fixes # (duplicate sidebar buttons)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes