### PR TITLE
Bug/instructors landing page layout

### DIFF
--- a/src/components/pages/LandingInstructor/HowItWorks.js
+++ b/src/components/pages/LandingInstructor/HowItWorks.js
@@ -13,7 +13,7 @@ const HowItWorks = () => {
     <Content className="il__mid">
       <Row>
         <Col span={24}>
-          <Title className="il__heading il__mid__heading">
+          <Title className="il__heading il__mid__heading" level={2}>
             HOW CODERHEROES WORKS
           </Title>
         </Col>
@@ -26,7 +26,7 @@ const HowItWorks = () => {
               style={{
                 fontSize: '1.4rem',
               }}
-              className="il__heading il__mid__heading"
+              className="il__heading il__heading_inner il__mid__heading"
             >
               WHAT KIND OF HELP DO YOU NEED?
             </Title>
@@ -47,7 +47,7 @@ const HowItWorks = () => {
               style={{
                 fontSize: '1.4rem',
               }}
-              className="il__heading il__mid__heading"
+              className="il__heading il__heading_inner il__mid__heading"
             >
               FIND AN INSTRUCTOR
             </Title>
@@ -68,7 +68,7 @@ const HowItWorks = () => {
               style={{
                 fontSize: '1.4rem',
               }}
-              className="il__heading il__mid__heading"
+              className="il__heading il__heading_inner il__mid__heading"
             >
               LEARN AT A LESSON
             </Title>
@@ -83,11 +83,9 @@ const HowItWorks = () => {
           </div>
         </Col>
       </Row>
-      <Row>
-        <Col span={8}>
-          <button className="il__browseBtn">BROWSE INSTRUCTORS</button>
-        </Col>
-      </Row>
+      <div className="il__browseBtn__container il__heading_inner">
+        <button className="il__browseBtn">BROWSE INSTRUCTORS</button>
+      </div>
     </Content>
   );
 };

--- a/src/components/pages/LandingInstructor/SearchInstructors.js
+++ b/src/components/pages/LandingInstructor/SearchInstructors.js
@@ -27,7 +27,10 @@ const SearchInstructors = props => {
       <Content className="il__top__topContent">
         <div className="il__top__topContent__container">
           <div className="il__top__topContent__main">
-            <Title className="il__heading il__top__topContent__heading">
+            <Title
+              className="il__heading il__top__topContent__heading"
+              level={2}
+            >
               ONLINE CODER INSTRUCTORS
             </Title>
             <Text className="il__top__topContent__text">
@@ -106,7 +109,7 @@ const SearchInstructors = props => {
                   whiteSpace: 'nowrap',
                   color: '#263E47',
                 }}
-                className="il__heading"
+                className="il__heading il__heading_inner"
               >
                 STUDENTS FIRST
               </Title>
@@ -129,7 +132,7 @@ const SearchInstructors = props => {
                   whiteSpace: 'nowrap',
                   color: '#263E47',
                 }}
-                className="il__heading"
+                className="il__heading il__heading_inner"
               >
                 QUALITY INSTRUCTION
               </Title>
@@ -151,7 +154,7 @@ const SearchInstructors = props => {
                   whiteSpace: 'nowrap',
                   color: '#263E47',
                 }}
-                className="il__heading"
+                className="il__heading il__heading_inner"
               >
                 AVAILABLE SCHEDULING
               </Title>
@@ -162,11 +165,9 @@ const SearchInstructors = props => {
             </div>
           </Col>
         </Row>
-        <Row>
-          <Col span={8}>
-            <button className="il__browseBtn">BROWSE INSTRUCTORS</button>
-          </Col>
-        </Row>
+        <div className="il__browseBtn__container il__heading_inner">
+          <button className="il__browseBtn">BROWSE INSTRUCTORS</button>
+        </div>
       </Content>
     </Layout>
   );

--- a/src/styles/InstructorLandingStyles/index.less
+++ b/src/styles/InstructorLandingStyles/index.less
@@ -14,6 +14,14 @@
 .il__heading {
   font-family: 'Staatliches', 'cursive';
 }
+.il__heading_inner{
+  display: flex;
+  justify-content: center;
+}
+.il__browseBtn__container {
+  display: flex;
+  flex-direction: row;
+  }
 .il__browseBtn {
   cursor: pointer;
   font-weight: bold;


### PR DESCRIPTION
## Description

The two blocks (components) of  Instructor landing paging, SearchInstructors which is on top and HowItWorks  which is on the middle, both have identical issues: the title font is overlapping, the element inside tag <Title> </Title> needs a flexbox wrapper (or, inner), the button division should parallel with Row.

Fixes # (issue)

## Loom Video

[https://www.loom.com/share/3a57a382f4514df29583e93e0aafcd24](https://www.loom.com/share/3a57a382f4514df29583e93e0aafcd24)

## Type of change

Please delete options that are not relevant.

- [v] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [v] My code follows the style guidelines of this project
- [v] I have performed a self-review of my own code
- [v] I have removed unnecessary comments/console logs from my code
- [v] I have made corresponding changes to the documentation if necessary (optional)
- [v] My changes generate no new warnings
- [v] I have checked my code and corrected any misspellings
- [v] No duplicate code left within changed files
- [v] Size of pull request kept to a minimum
- [v] Pull request description clearly describes changes made & motivations for said changes
