### PR TITLE
Centered tabs, removed card grid and added flexbox wraper for Parent/…

### DIFF
--- a/src/components/pages/ParentBooking/ParentBookingCard.js
+++ b/src/components/pages/ParentBooking/ParentBookingCard.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Card } from 'antd';
+import { Card, Button } from 'antd';
 import { dateConverter } from '../../common/dateHelpers';
 import { timeConverter } from '../../common/timeHelpers';
-import { Button } from '../../common';
 import axiosWithAuth from '../../../utils/axiosWithAuth';
 import { useOktaAuth } from '@okta/okta-react';
 
@@ -49,29 +48,23 @@ const ParentBookingCard = props => {
   ];
 
   return (
-    <div>
-      <Card className="card" hoverable="true" title={subject}>
-        <div className="card-container">
-          <div className="left">
-            {data.map((itm, idx) => {
-              return (
-                <div key={idx}>
-                  {itm.title}: {itm.text}
-                </div>
-              );
-            })}
+    <Card title={subject} style={{ width: 280 }} hoverable="true">
+      {data.map((itm, idx) => {
+        return (
+          <div key={idx}>
+            {itm.title}: {itm.text}
           </div>
-          <div className="right">
-            <img
-              className="image"
-              src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
-              alt="booking card"
-            />
-          </div>
-        </div>
-        <Button buttonText="ADD" handleClick={handleClick}></Button>
-      </Card>
-    </div>
+        );
+      })}
+      <Button
+        type="primary"
+        style={{ background: '#006C72', color: 'white' }}
+        block
+      >
+        {' '}
+        ADD{' '}
+      </Button>
+    </Card>
   );
 };
 

--- a/src/components/pages/ParentBooking/ParentBookingContainer.js
+++ b/src/components/pages/ParentBooking/ParentBookingContainer.js
@@ -50,15 +50,17 @@ const ParentBookingContainer = props => {
       ) : isFetching ? (
         <LoadingComponent message="Loading Bookings List..." />
       ) : (
-        <Tabs animated="true" tabPosition="top" onChange={renderTab}>
+        <Tabs animated="true" tabPosition="top" onChange={renderTab} centered>
           {tabs.map((item, index) => (
-            <TabPane tab={item.title} key={index}>
-              <Card.Grid hoverable="False" className="flex">
-                {currentTab &&
-                  currentTab.map((item, idx) => {
-                    return <ParentBookingCard key={idx} booking={item} />;
-                  })}
-              </Card.Grid>
+            <TabPane tab={item.title} key={index} className="tab_container">
+              {currentTab &&
+                currentTab.map((item, idx) => {
+                  return (
+                    <div>
+                      <ParentBookingCard key={idx} booking={item} />
+                    </div>
+                  );
+                })}
             </TabPane>
           ))}
           <TabPane tab="My Courses" key="3">

--- a/src/styles/ParentStyles/index.less
+++ b/src/styles/ParentStyles/index.less
@@ -117,7 +117,16 @@
 }
 }
 
-
+.tab_container {
+  display: flex;  
+  background-color: #edeed7;  
+}
+.tab_container > div {
+  background-color: #f1f1f1;
+  margin: 20px 0px  20px 50px;
+  
+  font-size: 30px;
+}
 
 .card-name {
   font-size: 1rem;
@@ -168,12 +177,13 @@
 }
 
 .card {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
-  width: 100%;
+
 }
+.tab_container{
+  display: flex;
+  flex-wrap: wrap;
+}
+
 
 .add-student-button {
   background-color: @btn__bg--orange;


### PR DESCRIPTION
## Description

I have removed the original NOT-working card-grided formate to add the simple flexbox which can fully show one different screen, and centered the tabs. 

Fixes # (Enable the parent/booing all available course cards flexible show-out and centered the tabs)

## Loom Video

[https://www.loom.com/share/46a087e753304270b111567b7ef5f659](https://www.loom.com/share/46a087e753304270b111567b7ef5f659)

## Type of change

Please delete options that are not relevant.

- [v] Bug fix (non-breaking change which fixes an issue)
- [v] New feature (non-breaking change which adds functionality)

## Checklist:

- [v] My code follows the style guidelines of this project
- [v] I have performed a self-review of my own code
- [v] I have removed unnecessary comments/console logs from my code
- [v] I have made corresponding changes to the documentation if necessary (optional)
- [v] My changes generate no new warnings
- [v] I have checked my code and corrected any misspellings
- [v] No duplicate code left within changed files
- [v] Size of pull request kept to a minimum
- [v] Pull request description clearly describes changes made & motivations for said changes
https://www.loom.com/share/30380f6de98a418d99e78cd1acc9c96c