### PR TITLE
BL-306 Resolved issue regarding removing Okta token from local storage upon …

### DIFF
--- a/src/components/common/Navbars/NavBar.js
+++ b/src/components/common/Navbars/NavBar.js
@@ -26,6 +26,7 @@ import NavBarLinks from './NavBarLinks';
 import { connect } from 'react-redux';
 
 import navLogo from '../../../img/navbar-logo.png';
+import handleLogout from '../../../utils/logout.js';
 
 const { SubMenu } = Menu;
 const { Header } = Layout;
@@ -40,11 +41,6 @@ function NavBar(props) {
     else if (role_id < 5) setBgColor('#21C5B5');
     else setBgColor('#FEAD2A');
   }, [role_id]);
-
-  const handleLogout = () => {
-    localStorage.removeItem('okta-token-storage');
-    window.location.reload();
-  };
 
   const showDrawer = () => {
     setVisible(true);

--- a/src/components/pages/ParentHome/ParentSidebar.js
+++ b/src/components/pages/ParentHome/ParentSidebar.js
@@ -17,6 +17,7 @@ import {
   FundProjectionScreenOutlined,
 } from '@ant-design/icons';
 import { useOktaAuth } from '@okta/okta-react';
+import handleLogout from '../../../utils/logout.js';
 
 const { Sider } = Layout;
 
@@ -24,6 +25,7 @@ const ParentSideBar = props => {
   const { cart, active } = props;
   const [collapsed, setCollapsed] = useState(false);
   const { authService } = useOktaAuth();
+
   const onCollapse = () => {
     if (collapsed === true) {
       setCollapsed(false);
@@ -144,11 +146,9 @@ const ParentSideBar = props => {
         <Menu.Item
           key="logout"
           icon={<ExportOutlined fontSize="150px" />}
-          onClick={() => {
-            authService.logout();
-          }}
+          onClick={handleLogout}
         >
-          <Link>Logout</Link>
+          <Link to="/">Logout</Link>
         </Menu.Item>
         <Menu.Item key="4" icon={<ShoppingCartOutlined fontSize="150px" />}>
           <Link to="/cart" className="link">

--- a/src/utils/logout.js
+++ b/src/utils/logout.js
@@ -1,0 +1,6 @@
+const handleLogout = () => {
+  localStorage.removeItem('okta-token-storage');
+  window.location.reload();
+};
+
+export default handleLogout;


### PR DESCRIPTION
…logging out using the side-bar log-out button

## Description

We found that clicking the logout button on the sidebar did not log a user out, it did not fully clear/remove the Okta token from local storage. We wrote a handleLogout function to remove the access token upon clicking the logout button. For consistencies sake, we used the same function on the NavBar logout button, abstracting away the function to a separate file.

Fixes # (issue)
Logout on Sidebar not logging users out

## Loom Video

https://www.loom.com/share/81bcab5c5e5a4bf9b61cfd5f51b659fa

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have removed unnecessary comments/console logs from my code
- [ ] I have made corresponding changes to the documentation if necessary (optional)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
- [ ] No duplicate code left within changed files
- [ ] Size of pull request kept to a minimum
- [ ] Pull request description clearly describes changes made & motivations for said changes

Worked with: @DawsonReschke and @Benroberts37  