### PR TITLE
BL-784 feature/parent_family/add_child_profile

### DIFF
--- a/src/components/pages/InstructorNewsFeed/NewsContainer.js
+++ b/src/components/pages/InstructorNewsFeed/NewsContainer.js
@@ -8,7 +8,7 @@ import { useOktaAuth } from '@okta/okta-react';
 function NewsContainer(props) {
   const { newsfeed, dispatch } = props;
   const { authState } = useOktaAuth();
-  const { idToken } = authState;
+  const { idToken } = authState.idToken;
 
   useEffect(() => {
     dispatch(getNewsFeeds(idToken));

--- a/src/components/pages/ParentFamily/ParentFamilyHome.js
+++ b/src/components/pages/ParentFamily/ParentFamilyHome.js
@@ -31,13 +31,13 @@ const ParentFamilyHome = props => {
     false
   );
   const [alertMsg, setAlertMsg] = useState(0);
+  const dispatch = useDispatch();
 
   // useEffect(() => {
     // TODO: In the following line, "4" is hardcoded instead of profile_id because currently profile_id is not being passed along in props.user . profile_id 4 exists in our seeds, so it has been hardcoded to display the existing seeded child. currentUser is initializing as empty object {} and is not being updated. When this is fixed, change the hardcoded "4" to "profile_id" and it should work.
     dispatch(getChildren(idToken, 4));
   }, [dispatch, idToken]);
 
-  const dispatch = useDispatch();
   const { user, children } = props;
 
   const showAddStudentModal = () => {

--- a/src/components/pages/ParentFamily/ParentFamilyHome.js
+++ b/src/components/pages/ParentFamily/ParentFamilyHome.js
@@ -39,7 +39,7 @@ const ParentFamilyHome = props => {
   const { user, children } = props;
 
   useEffect(() => {
-    // In the following line, "4" is hardcoded instead of profile_id because currently profile_id is not being passed along in props.user . profile_id 4 exists in our seeds, so it has been hardcoded to display the existing seeded child. currentUser is initializing as empty object {} and is not being updated. When this is fixed, change the hardcoded "4" to "profile_id" and it should work.
+    // TODO: In the following line, "4" is hardcoded instead of profile_id because currently profile_id is not being passed along in props.user . profile_id 4 exists in our seeds, so it has been hardcoded to display the existing seeded child. currentUser is initializing as empty object {} and is not being updated. When this is fixed, change the hardcoded "4" to "profile_id" and it should work.
     dispatch(getChildren(idToken, 4));
   }, [dispatch, idToken]);
 
@@ -153,7 +153,6 @@ const ParentFamilyHome = props => {
 };
 
 const mapStateToProps = state => {
-  console.log('state:', state.userReducer.currentUser);
   return {
     user: state.userReducer.currentUser,
     children: state.parentReducer.children,

--- a/src/components/pages/ParentFamily/ParentFamilyHome.js
+++ b/src/components/pages/ParentFamily/ParentFamilyHome.js
@@ -35,8 +35,8 @@ const ParentFamilyHome = props => {
 
   // useEffect(() => {
     // TODO: In the following line, "4" is hardcoded instead of profile_id because currently profile_id is not being passed along in props.user . profile_id 4 exists in our seeds, so it has been hardcoded to display the existing seeded child. currentUser is initializing as empty object {} and is not being updated. When this is fixed, change the hardcoded "4" to "profile_id" and it should work.
-    dispatch(getChildren(idToken, 4));
-  }, [dispatch, idToken]);
+    // dispatch(getChildren(idToken, 4));
+  // }, [dispatch, idToken]);
 
   const { user, children } = props;
 

--- a/src/components/pages/ParentFamily/ParentFamilyHome.js
+++ b/src/components/pages/ParentFamily/ParentFamilyHome.js
@@ -21,7 +21,6 @@ import { useOktaAuth } from '@okta/okta-react';
 import { getChildren } from '../../../redux/actions/parentActions';
 
 const ParentFamilyHome = props => {
-  console.log(`the user is: ${JSON.stringify(props.user)}`);
   const { Meta } = Card;
   const { Content } = Layout;
   const { Text } = Typography;
@@ -33,16 +32,16 @@ const ParentFamilyHome = props => {
   );
   const [alertMsg, setAlertMsg] = useState(0);
 
-  const { authState, oktaAuth } = useOktaAuth();
+  const { authState } = useOktaAuth();
+  const { idToken } = authState.idToken;
 
   const dispatch = useDispatch();
   const { user, children } = props;
 
   useEffect(() => {
-    oktaAuth.token.getUserInfo().then(dataProfile => {
-      dispatch(getChildren(authState.idToken.idToken, dataProfile.sub));
-    });
-  }, [dispatch, oktaAuth.token, authState.idToken.idToken]);
+    // In the following line, "4" is hardcoded instead of profile_id because currently profile_id is not being passed along in props.user . profile_id 4 exists in our seeds, so it has been hardcoded to display the existing seeded child. currentUser is initializing as empty object {} and is not being updated. When this is fixed, change the hardcoded "4" to "profile_id" and it should work.
+    dispatch(getChildren(idToken, 4));
+  }, [dispatch, idToken]);
 
   const showAddStudentModal = () => {
     setAddStudentVisible(true);
@@ -154,6 +153,7 @@ const ParentFamilyHome = props => {
 };
 
 const mapStateToProps = state => {
+  console.log('state:', state.userReducer.currentUser);
   return {
     user: state.userReducer.currentUser,
     children: state.parentReducer.children,

--- a/src/redux/actions/parentActions.js
+++ b/src/redux/actions/parentActions.js
@@ -20,7 +20,6 @@ export const CLEAR_CART = 'CLEAR_CART';
 export const GET_NEWSFEEDS_PARENT = 'GET_NEWSFEEDS_PARENT';
 
 export const getChildren = (idToken, profile_id) => async dispatch => {
-  console.log('getChildren profile_id:', profile_id);
   axiosWithAuth(idToken)
     .get(`/parent/${profile_id}/children`)
     .then(res => {

--- a/src/redux/actions/parentActions.js
+++ b/src/redux/actions/parentActions.js
@@ -20,15 +20,27 @@ export const CLEAR_CART = 'CLEAR_CART';
 export const GET_NEWSFEEDS_PARENT = 'GET_NEWSFEEDS_PARENT';
 
 export const getChildren = (idToken, profile_id) => async dispatch => {
-  dispatch({ type: GET_CHILDREN_ACTION });
-  axiosWithAuth(idToken)
-    .get(`/parent/${profile_id}/children`)
-    .then(res => {
-      dispatch({ type: GET_CHILDREN_SUCCESS, payload: res.data });
-    })
-    .catch(err => {
-      dispatch({ type: ERROR_ACTION, payload: err });
+  try {
+    axiosWithAuth(idToken)
+      .get(`/parent/${profile_id}/children`)
+      .then(res => {
+        dispatch({
+          type: GET_CHILDREN_SUCCESS,
+          payload: res.data,
+        });
+      })
+      .catch(err => {
+        dispatch({
+          type: ERROR_ACTION,
+          payload: err,
+        });
+      });
+  } catch (error) {
+    dispatch({
+      type: ERROR_ACTION,
+      payload: error.message,
     });
+  }
 };
 export const getCourses = dispatch => {
   dispatch({ type: GET_COURSES_ACTION });

--- a/src/redux/actions/parentActions.js
+++ b/src/redux/actions/parentActions.js
@@ -20,27 +20,21 @@ export const CLEAR_CART = 'CLEAR_CART';
 export const GET_NEWSFEEDS_PARENT = 'GET_NEWSFEEDS_PARENT';
 
 export const getChildren = (idToken, profile_id) => async dispatch => {
-  try {
-    axiosWithAuth(idToken)
-      .get(`/parent/${profile_id}/children`)
-      .then(res => {
-        dispatch({
-          type: GET_CHILDREN_SUCCESS,
-          payload: res.data,
-        });
-      })
-      .catch(err => {
-        dispatch({
-          type: ERROR_ACTION,
-          payload: err,
-        });
+  console.log('getChildren profile_id:', profile_id);
+  axiosWithAuth(idToken)
+    .get(`/parent/${profile_id}/children`)
+    .then(res => {
+      dispatch({
+        type: GET_CHILDREN_SUCCESS,
+        payload: res.data,
       });
-  } catch (error) {
-    dispatch({
-      type: ERROR_ACTION,
-      payload: error.message,
+    })
+    .catch(err => {
+      dispatch({
+        type: ERROR_ACTION,
+        payload: err.message,
+      });
     });
-  }
 };
 export const getCourses = dispatch => {
   dispatch({ type: GET_COURSES_ACTION });

--- a/src/redux/reducers/parentReducer.js
+++ b/src/redux/reducers/parentReducer.js
@@ -39,8 +39,6 @@ const removeCartItem = (cart, booking) => {
 };
 
 const parentReducer = (state = initialState, action) => {
-  console.log('action.type:', action.type);
-  console.log('action.payload:', action.payload);
   switch (action.type) {
     case GET_COURSES_ACTION:
       return {

--- a/src/redux/reducers/parentReducer.js
+++ b/src/redux/reducers/parentReducer.js
@@ -28,7 +28,7 @@ const removeCartItem = (cart, booking) => {
   return cart;
 };
 
-const reducer = (state = parentDummyData, action) => {
+const parentReducer = (state = parentDummyData, action) => {
   switch (action.type) {
     case GET_COURSES_ACTION:
       return {
@@ -114,4 +114,4 @@ const reducer = (state = parentDummyData, action) => {
   }
 };
 
-export default reducer;
+export default parentReducer;

--- a/src/redux/reducers/parentReducer.js
+++ b/src/redux/reducers/parentReducer.js
@@ -1,4 +1,3 @@
-import { parentDummyData } from '../../parentDummyData';
 import {
   ADD_TO_CART,
   CANCEL_CART_ITEM,
@@ -15,6 +14,17 @@ import {
   GET_NEWSFEEDS_PARENT,
 } from '../actions/parentActions';
 
+const initialState = {
+  availableCourses: [],
+  bookings: null,
+  cart: [],
+  children: [],
+  courses: [],
+  inbox: [],
+  newsfeed: [],
+  sessions: [],
+};
+
 const removeCartItem = (cart, booking) => {
   for (let i = 0; i < cart.length; i++) {
     if (
@@ -28,7 +38,9 @@ const removeCartItem = (cart, booking) => {
   return cart;
 };
 
-const parentReducer = (state = parentDummyData, action) => {
+const parentReducer = (state = initialState, action) => {
+  console.log('action.type:', action.type);
+  console.log('action.payload:', action.payload);
   switch (action.type) {
     case GET_COURSES_ACTION:
       return {
@@ -55,7 +67,6 @@ const parentReducer = (state = parentDummyData, action) => {
         ...state,
         inbox: action.payload,
       };
-
     case SIGNUP_COURSE_ACTION:
       return {
         ...state,


### PR DESCRIPTION
## Description

Jira Ticket # **BL-784** Feature: ParentFamilyHome (ParentFamily) should properly display a parent's children. We want to start with the basics of a parent adding a profile for their child, similar to how we see profiles in the popular streaming apps like Netflix and Disney+.

Co-Author: **Vasilii Garanin**

## Fixes

- ParentFamilyHome now displays a parent's children
- Updated getChildren function in parent actions for catch error payload to err.message
- Created initialState in parentReducer
- Removed hardcoded parentDummyData from parentReducer, and instead initializing with new initialState
- Updated useEffect in ParentFamilyHome, currently hardcoded with an existing seeded profile_id, and left a comment for future programmers to update this once profile_id is properly passed along in currentUser (userActions/ userReducer)
- Also included idToken in InstructorNewsFeed NewsContainer (which is a previous ticket we worked on, included this update to  maintain page functionality following Okta version update)

## Loom Video

We were not able to fit full explanation into 5 minutes, so will link 2 videos below:

- [1] https://www.loom.com/share/9fd75fe4807e4fb693bdfff3f8d31c29
- [2] https://www.loom.com/share/248cecab16044a52a5eb4ac0f9b036ff

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [X] I have made corresponding changes to the documentation if necessary (optional)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes
